### PR TITLE
Switch GitHub URLs from git protocol to https

### DIFF
--- a/recipes-ham/csdr/csdr_git.bb
+++ b/recipes-ham/csdr/csdr_git.bb
@@ -8,7 +8,7 @@ HOMEPAGE = "https://github.com/ha7ilm/csdr"
 LICENSE = "BSD & GPLv3+"
 LIC_FILES_CHKSUM = "file://README.md;md5=655403e2809c61b2c0bc7446f148cfd7"
 
-SRC_URI = "git://github.com/simonyiszk/csdr.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/simonyiszk/csdr.git;protocol=https;branch=master \
            file://0001-Adjust-makefile-for-yocto-build.patch \
           "
 

--- a/recipes-ham/cubicsdr/cubicsdr_git.bb
+++ b/recipes-ham/cubicsdr/cubicsdr_git.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://cubicsdr.com/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/cjcliffe/CubicSDR.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/cjcliffe/CubicSDR.git;protocol=https;branch=master \
           "
 
 SRCREV = "7b1956f7cd48e9adb520d862814573dd3130e59f"

--- a/recipes-ham/direwolf/direwolf_1.6.bb
+++ b/recipes-ham/direwolf/direwolf_1.6.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/wb2osz/direwolf/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fa22e16ebbe6638b2bd253338fbded9f"
 
-SRC_URI = "git://github.com/wb2osz/direwolf.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/wb2osz/direwolf.git;protocol=https;branch=master \
           "
 
 SRCREV = "413855e7915865db998239e8383cb7f84d5ac1bd"

--- a/recipes-ham/kalibrate-rtl/kalibrate-rtl_git.bb
+++ b/recipes-ham/kalibrate-rtl/kalibrate-rtl_git.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=0eae42b21c81e0e7c8c3e8a545e156c9"
 DEPENDS = "fftw rtlsdr"
 
 SRCREV = "66074b82daf4a1c588ce1c565a145fac1c59ec56"
-SRC_URI = "git://github.com/steve-m/kalibrate-rtl.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/steve-m/kalibrate-rtl.git;protocol=https;branch=master \
           "
 S = "${WORKDIR}/git"
 

--- a/recipes-ham/liquiddsp/liquiddsp_git.bb
+++ b/recipes-ham/liquiddsp/liquiddsp_git.bb
@@ -10,7 +10,7 @@ HOMEPAGE = "https://liquidsdr.org/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=860e4083ceb93ce0939b1a58fcaacb53"
 
-SRC_URI = "git://github.com/jgaeddert/liquid-dsp.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/jgaeddert/liquid-dsp.git;protocol=https;branch=master \
           "
 
 SRCREV = "c68f5e39434433c88bd4fe19784bf4c8a32aa8e4"

--- a/recipes-ham/rtlsdr/rtlsdr_git.bb
+++ b/recipes-ham/rtlsdr/rtlsdr_git.bb
@@ -12,7 +12,7 @@ DEPENDS = "libusb1"
 RDEPENDS:${PN} = "libusb1"
 
 SRCREV = "0d825fe08ef1e0225340fa7d8dffa621ad80a818"
-SRC_URI = "git://github.com/keenerd/rtl-sdr.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/keenerd/rtl-sdr.git;protocol=https;branch=master \
            file://01_fix_pkgconfig.patch \
           "
 S = "${WORKDIR}/git"

--- a/recipes-ham/soapysdr/soapyremote_0.5.2.bb
+++ b/recipes-ham/soapysdr/soapyremote_0.5.2.bb
@@ -10,7 +10,7 @@ LICENSE = "BSL-1.0 & MIT & Python-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE_1_0.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
 SRCREV = "f920d9bf10f62f67c8e31b7dc25090bc784e5210"
-SRC_URI = "git://github.com/pothosware/SoapyRemote.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/pothosware/SoapyRemote.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"

--- a/recipes-ham/soapysdr/soapyrtlsdr_0.3.1.bb
+++ b/recipes-ham/soapysdr/soapyrtlsdr_0.3.1.bb
@@ -9,7 +9,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=76c8dd204c0791e9a30c30d0406b75da"
 
 SRCREV = "bec4f0504b29369fd8ff651e6954b960991bc1b1"
-SRC_URI = "git://github.com/pothosware/SoapyRTLSDR.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/pothosware/SoapyRTLSDR.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"

--- a/recipes-ham/soapysdr/soapysdr_0.8.1.bb
+++ b/recipes-ham/soapysdr/soapysdr_0.8.1.bb
@@ -9,7 +9,7 @@ LICENSE = "BSL-1.0 & MIT & Python-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE_1_0.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
 
 SRCREV = "1cf5a539a21414ff509ff7d0eedfc5fa8edb90c6"
-SRC_URI = "git://github.com/pothosware/SoapySDR.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/pothosware/SoapySDR.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
GitHub no longer supports git protocol. Switch to https.

Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>