### PR TITLE
Yocto whinlatter recipe update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This layer depends on:
   * branches: `kirkstone`/`scarthgap`
 * URI: http://git.openembedded.org/meta-openembedded
   * layer: `meta-oe`
-  * branches: `kirkstone`/`scarthgap`
+  * branches: `whinlatter`
 
 Optional dependencies:
 
@@ -21,7 +21,7 @@ Optional dependencies:
   * branches: `kirkstone`/`scarthgap`
 * URI: http://git.openembedded.org/meta-openembedded
   * layer: `meta-networking`
-  * branches: `kirkstone`/`scarthgap`
+  * branches: `whinlatter`
 
 ## Issues & contributions
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_meta-amateurradio = "6"
 LAYERDEPENDS_meta-amateurradio = "core"
 LAYERDEPENDS_meta-amateurradio += "openembedded-layer"
 
-LAYERSERIES_COMPAT_meta-amateurradio = "kirkstone scarthgap"
+LAYERSERIES_COMPAT_meta-amateurradio = "whinlatter kirkstone scarthgap"
 
 BBFILES_DYNAMIC += " \
   qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_meta-amateurradio = "6"
 LAYERDEPENDS_meta-amateurradio = "core"
 LAYERDEPENDS_meta-amateurradio += "openembedded-layer"
 
-LAYERSERIES_COMPAT_meta-amateurradio = "whinlatter kirkstone scarthgap"
+LAYERSERIES_COMPAT_meta-amateurradio = "whinlatter"
 
 BBFILES_DYNAMIC += " \
   qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \

--- a/dynamic-layers/qt5-layer/recipes-ham/js8call/files/0001-Disable-openmp-code.patch
+++ b/dynamic-layers/qt5-layer/recipes-ham/js8call/files/0001-Disable-openmp-code.patch
@@ -1,3 +1,6 @@
+
+Upstream-Status: Pending
+
 From eb082a607e646fa0c729201d8cabb1abab762473 Mon Sep 17 00:00:00 2001
 From: Adrian Stratulat <adrian.stratulat@enea.com>
 Date: Sat, 30 Nov 2019 12:06:23 +0200

--- a/dynamic-layers/qt5-layer/recipes-ham/js8call/files/0001-fix-libboost-search-path.patch
+++ b/dynamic-layers/qt5-layer/recipes-ham/js8call/files/0001-fix-libboost-search-path.patch
@@ -1,3 +1,6 @@
+
+Upstream-Status: Pending
+
 From 6e8d6d223738878f0711f353f4539471dd2d486f Mon Sep 17 00:00:00 2001
 From: Adrian Stratulat <adrian.stratulat91@gmail.com>
 Date: Sun, 4 Apr 2021 00:14:23 +0300

--- a/dynamic-layers/qt5-layer/recipes-ham/js8call/js8call_2.2.0.bb
+++ b/dynamic-layers/qt5-layer/recipes-ham/js8call/js8call_2.2.0.bb
@@ -15,8 +15,6 @@ SRC_URI = "git://bitbucket.org/widefido/js8call.git;protocol=https;branch=js8cal
 
 SRCREV = "99018054a3b273f7086f4e086f5b848c645c23c8"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "qttools-native asciidoc-native libgfortran boost fftw libusb \
            qtmultimedia qtserialport hamlib qttools"
 
@@ -30,12 +28,13 @@ inherit cmake_qt5
 # wsjtx
 EXTRA_OECMAKE = " \
                  -Dhamlib_LIBRARY_DIRS='${WORKDIR}/recipe-sysroot/usr/lib/' \
+                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
                 "
 
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
 OECMAKE_GENERATOR = "Unix Makefiles"
 
-INSANE_SKIP:${PN} += "already-stripped"
+INSANE_SKIP:${PN} += "already-stripped buildpaths"
 
 # Because some of the code is written in fortran, we'll need GCC with fortran
 # support built-in. To enable this, you must add the following line to the

--- a/dynamic-layers/qt5-layer/recipes-ham/qsstv/qsstv_git.bb
+++ b/dynamic-layers/qt5-layer/recipes-ham/qsstv/qsstv_git.bb
@@ -4,22 +4,18 @@ DESCRIPTION = "QSSTV is a program for receiving and transmitting SSTV and \
 HAMDRM (sometimes called DSSTV). It is compatible with most of MMSSTV and \
 EasyPal."
 
-HOMEPAGE = "http://users.telenet.be/on4qz/index.html"
+HOMEPAGE = "https://www.cqsstv.com/"
 
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=57baf3d8c07efa88a6a07754076c97d7"
 
-SRC_URI = "http://users.telenet.be/on4qz/qsstv/downloads/${BPN}_${PV}.tar.gz \
+SRCREV = "8c27d6d169d8c6c197eb47c2089870e39bc06a02"
+SRC_URI = "git://github.com/ON4QZ/QSSTV.git;protocol=https;branch=main \
           "
-MIRRORS += "http://users.telenet.be/on4qz/qsstv/downloads/ https://low-level.wiki/large_files/"
-
-SRC_URI[md5sum] = "99e7fecd91f6c9bf211395fddceba44c"
-SRC_URI[sha256sum] = "c03f7fa5c680ced8fd331c25ff3e47440c9aedb48ec7b66255c6aa0ed88e7a68"
-
-S = "${WORKDIR}/${BPN}"
 
 inherit qmake5 pkgconfig
 
 DEPENDS = "openjpeg alsa-lib pulseaudio hamlib fftw v4l-utils qtbase"
 
+QMAKE_PROFILES += "${S}/src/${PN}.pro"
 EXTRA_QMAKEVARS_PRE += "PREFIX=${prefix}"

--- a/dynamic-layers/qt5-layer/recipes-ham/wsjtx/files/0001-Add-shmem-dependency-to-jt9.patch
+++ b/dynamic-layers/qt5-layer/recipes-ham/wsjtx/files/0001-Add-shmem-dependency-to-jt9.patch
@@ -1,3 +1,6 @@
+
+Upstream-Status: Pending
+
 From ba0a61a47ca36a15836505db63a3e1274571b2a4 Mon Sep 17 00:00:00 2001
 From: Adrian Stratulat <adrian.stratulat91@gmail.com>
 Date: Tue, 2 Jun 2020 23:13:18 +0300

--- a/dynamic-layers/qt5-layer/recipes-ham/wsjtx/files/0002-Disable-openmp-code.patch
+++ b/dynamic-layers/qt5-layer/recipes-ham/wsjtx/files/0002-Disable-openmp-code.patch
@@ -1,3 +1,6 @@
+
+Upstream-Status: Pending
+
 From 515db3d9469838f9ecfb4145e8b5304662b80480 Mon Sep 17 00:00:00 2001
 From: Adrian Stratulat <adrian.stratulat91@gmail.com>
 Date: Tue, 2 Jun 2020 23:34:48 +0300

--- a/dynamic-layers/qt5-layer/recipes-ham/wsjtx/wsjtx_2.6.1.bb
+++ b/dynamic-layers/qt5-layer/recipes-ham/wsjtx/wsjtx_2.6.1.bb
@@ -19,8 +19,6 @@ SRC_URI = "git://git.code.sf.net/p/wsjt/wsjtx;protocol=git;nobranch=1 \
 # the wsjtx-2.6.1 tag:
 SRCREV = "848a38f1b46ea3dde9f45f104b6ec098eba35689"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "qttools-native asciidoc-native libgfortran boost fftw libusb \
            qtmultimedia qtserialport hamlib qttools portaudio-v19"
 
@@ -39,7 +37,7 @@ EXTRA_OECMAKE = " \
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
 OECMAKE_GENERATOR = "Unix Makefiles"
 
-INSANE_SKIP:${PN} += "already-stripped"
+INSANE_SKIP:${PN} += "already-stripped buildpaths"
 
 # Because some of the code is written in fortran, we'll need GCC with fortran
 # support built-in. To enable this, you must add the following line to the

--- a/recipes-graphics/goocanvas/files/0001-set-model-cast.patch
+++ b/recipes-graphics/goocanvas/files/0001-set-model-cast.patch
@@ -1,0 +1,14 @@
+
+Upstream-Status: Pending
+
+--- a/src/goocanvasitemsimple.c	2026-05-04 15:14:17.958421478 +0000
++++ b/src/goocanvasitemsimple.c	2026-05-04 15:14:05.082135653 +0000
+@@ -1536,7 +1536,7 @@
+   goo_canvas_item_simple_free_data (item->simple_data);
+   g_slice_free (GooCanvasItemSimpleData, item->simple_data);
+ 
+-  item->model = g_object_ref (model);
++  item->model = (GooCanvasItemModelSimple*)g_object_ref (model);
+   item->simple_data = &item->model->simple_data;
+ 
+   if (accessibility_enabled)

--- a/recipes-graphics/goocanvas/goocanvas_2.0.4.bb
+++ b/recipes-graphics/goocanvas/goocanvas_2.0.4.bb
@@ -10,6 +10,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=3bf50002aefd002f49e7bb854063f7e7"
 
 SRC_URI = "http://ftp.gnome.org/pub/GNOME/sources/goocanvas/2.0/goocanvas-2.0.4.tar.xz \
+           file://0001-set-model-cast.patch \
           "
 SRC_URI[md5sum] = "a603f9459d29348b88ba3592bca03274"
 SRC_URI[sha256sum] = "c728e2b7d4425ae81b54e1e07a3d3c8a4bd6377a63cffa43006045bceaa92e90"
@@ -17,3 +18,7 @@ SRC_URI[sha256sum] = "c728e2b7d4425ae81b54e1e07a3d3c8a4bd6377a63cffa43006045bcea
 inherit autotools gettext gtk-doc gobject-introspection
 
 DEPENDS = "cairo gtk+3"
+
+do_compile:prepend () {
+    sed -i -e 's|${TMPDIR}||g' ${S}/src/goocanvasitemsimple.c
+}

--- a/recipes-ham/csdr/csdr_git.bb
+++ b/recipes-ham/csdr/csdr_git.bb
@@ -13,9 +13,6 @@ SRC_URI = "git://github.com/simonyiszk/csdr.git;protocol=https;branch=master \
           "
 
 SRCREV = "6ef2a74206887155290a54c7117636f66742f858"
-S = "${WORKDIR}/git"
-
-inherit autotools-brokensep
 
 DEPENDS = "fftw"
 RDEPENDS:${PN} = "bash"

--- a/recipes-ham/csdr/files/0001-Adjust-makefile-for-yocto-build.patch
+++ b/recipes-ham/csdr/files/0001-Adjust-makefile-for-yocto-build.patch
@@ -1,3 +1,6 @@
+
+Upstream-Status: Pending
+
 From 114feaf3abc89ea192cb104494b672596a4b4309 Mon Sep 17 00:00:00 2001
 From: Adrian Stratulat <adrian.stratulat91@gmail.com>
 Date: Wed, 26 Dec 2019 14:04:42 +0000

--- a/recipes-ham/cubicsdr/cubicsdr_git.bb
+++ b/recipes-ham/cubicsdr/cubicsdr_git.bb
@@ -14,9 +14,8 @@ SRC_URI = "git://github.com/cjcliffe/CubicSDR.git;protocol=https;branch=master \
 
 SRCREV = "7b1956f7cd48e9adb520d862814573dd3130e59f"
 
-S = "${WORKDIR}/git"
-
 inherit cmake
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 DEPENDS = "virtual/libgles2 wxwidgets liquiddsp soapysdr pulseaudio"
 RDEPENDS:${PN} = "liquiddsp-dev"
 

--- a/recipes-ham/direwolf/direwolf_1.7.bb
+++ b/recipes-ham/direwolf/direwolf_1.7.bb
@@ -14,12 +14,11 @@ SRC_URI = "git://github.com/wb2osz/direwolf.git;protocol=https;branch=master \
 
 SRCREV = "de293a1f2526ec6639fe31fa411bd4f2319ecdf4"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "alsa-lib udev"
 RDEPENDS:${PN} = "bash perl"
 
 inherit cmake
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 do_install:append() {
 	rm -f ${D}/usr/bin/telem-volts.py

--- a/recipes-ham/fldigi/fldigi_4.2.05.bb
+++ b/recipes-ham/fldigi/fldigi_4.2.05.bb
@@ -14,8 +14,11 @@ SRC_URI = "git://git.code.sf.net/p/fldigi/fldigi;protocol=git;branch=master \
 # tag v4.2.05
 SRCREV = "03b6d3d97a75ae8f65282f4be21e7f5bb0ab18a6"
 
-S = "${WORKDIR}/git"
-
 inherit autotools gettext pkgconfig
 
 DEPENDS = "fltk udev libsamplerate0 portaudio-v19"
+
+# Remove build host references before building [fixes Q buildpath]
+do_compile:prepend () {
+    sed -i -e 's|${TMPDIR}||g' ${B}/src/config.h
+}

--- a/recipes-ham/gpredict/gpredict.inc
+++ b/recipes-ham/gpredict/gpredict.inc
@@ -1,0 +1,25 @@
+SUMMARY = "Gpredict"
+
+DESCRIPTION = "Gpredict is a real-time satellite tracking and orbit prediction \
+application. It can track a large number of satellites and display their \
+position and other data in lists, tables, maps, and polar plots (radar view)."
+
+HOMEPAGE = "http://gpredict.oz9aec.net/"
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=892f569a555ba9c07a568a7c0c4fa63a"
+
+SRC_URI = "https://github.com/csete/gpredict/releases/download/v${PV}/gpredict-${PV}.tar.bz2 \
+          "
+
+SRC_URI[md5sum] = "38a7bda79989c5921d1c0bcc6c238382"
+SRC_URI[sha256sum] = "e759c4bae0b17b202a7c0f8281ff016f819b502780d3e77b46fe8767e7498e43"
+
+inherit autotools-brokensep gettext pkgconfig
+
+DEPENDS = "glib-2.0-native libtool-native intltool-native curl glib-2.0 goocanvas"
+
+CFLAGS:append = " -Wl,--allow-multiple-definition"
+RSUGGESTS:${PN} = "ntpdate"
+
+FILES:${PN} += "${prefix}/share"

--- a/recipes-ham/gpredict/gpredict_2.2.1.bb
+++ b/recipes-ham/gpredict/gpredict_2.2.1.bb
@@ -1,23 +1,6 @@
-SUMMARY = "Gpredict"
+require gpredict.inc
 
-DESCRIPTION = "Gpredict is a real-time satellite tracking and orbit prediction \
-application. It can track a large number of satellites and display their \
-position and other data in lists, tables, maps, and polar plots (radar view)."
-
-HOMEPAGE = "http://gpredict.oz9aec.net/"
-
-LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=892f569a555ba9c07a568a7c0c4fa63a"
-
-SRC_URI = "https://github.com/csete/gpredict/releases/download/v2.2.1/gpredict-2.2.1.tar.bz2 \
-          "
 
 SRC_URI[md5sum] = "38a7bda79989c5921d1c0bcc6c238382"
 SRC_URI[sha256sum] = "e759c4bae0b17b202a7c0f8281ff016f819b502780d3e77b46fe8767e7498e43"
-
-inherit autotools-brokensep gettext pkgconfig
-
-DEPENDS = "glib-2.0-native libtool-native intltool-native curl glib-2.0 goocanvas"
-
-CFLAGS:append = " -Wl,--allow-multiple-definition"
-RSUGGESTS:${PN} = "ntpdate"

--- a/recipes-ham/gpredict/gpredict_2.5.1.bb
+++ b/recipes-ham/gpredict/gpredict_2.5.1.bb
@@ -1,0 +1,6 @@
+require gpredict.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=892f569a555ba9c07a568a7c0c4fa63a"
+
+SRC_URI[md5sum] = "c6acc86f9a0bf3eb8673557775e13604"
+SRC_URI[sha256sum] = "c26ff5f9bfe9468bd48426dac4782f860c208960b0551feba3e38e364fbcd797"

--- a/recipes-ham/hamlib/hamlib_4.5.6.bb
+++ b/recipes-ham/hamlib/hamlib_4.5.6.bb
@@ -16,8 +16,6 @@ SRCREV = "8832ad144a5f9e9990bc540c0b5cfc9f26e0f193"
 
 DEPENDS = "libusb1 readline"
 
-S = "${WORKDIR}/git"
-
 inherit autotools
 
 # WSJT-X requires the /usr/bin files from here to be available in the sysroot

--- a/recipes-ham/kalibrate-rtl/kalibrate-rtl_git.bb
+++ b/recipes-ham/kalibrate-rtl/kalibrate-rtl_git.bb
@@ -14,6 +14,4 @@ DEPENDS = "fftw rtlsdr"
 SRCREV = "66074b82daf4a1c588ce1c565a145fac1c59ec56"
 SRC_URI = "git://github.com/steve-m/kalibrate-rtl.git;protocol=https;branch=master \
           "
-S = "${WORKDIR}/git"
-
 inherit autotools pkgconfig

--- a/recipes-ham/liquiddsp/liquiddsp_git.bb
+++ b/recipes-ham/liquiddsp/liquiddsp_git.bb
@@ -15,8 +15,6 @@ SRC_URI = "git://github.com/jgaeddert/liquid-dsp.git;protocol=https;branch=maste
 
 SRCREV = "c68f5e39434433c88bd4fe19784bf4c8a32aa8e4"
 
-S = "${WORKDIR}/git"
-
 inherit autotools-brokensep
 INSANE_SKIP:${PN}-dev += "dev-elf"
 RDEPENDS:${PN}-dev = ""

--- a/recipes-ham/rtlsdr/files/01_fix_pkgconfig.patch
+++ b/recipes-ham/rtlsdr/files/01_fix_pkgconfig.patch
@@ -1,3 +1,6 @@
+
+Upstream-Status: Pending
+
 # YLB @ Axios provided this patch in openembedded-hawk
 # There's not a cleaner way to get at this variable post-patch
 # in bitbake so far as BTG can tell, either.

--- a/recipes-ham/rtlsdr/rtlsdr_git.bb
+++ b/recipes-ham/rtlsdr/rtlsdr_git.bb
@@ -15,6 +15,4 @@ SRCREV = "0d825fe08ef1e0225340fa7d8dffa621ad80a818"
 SRC_URI = "git://github.com/keenerd/rtl-sdr.git;protocol=https;branch=master \
            file://01_fix_pkgconfig.patch \
           "
-S = "${WORKDIR}/git"
-
 inherit autotools pkgconfig

--- a/recipes-ham/soapysdr/soapyremote_0.5.2.bb
+++ b/recipes-ham/soapysdr/soapyremote_0.5.2.bb
@@ -13,10 +13,8 @@ SRCREV = "f920d9bf10f62f67c8e31b7dc25090bc784e5210"
 SRC_URI = "git://github.com/pothosware/SoapyRemote.git;protocol=https;branch=master \
           "
 
-S = "${WORKDIR}/git"
-
 inherit cmake
-
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 DEPENDS = "soapysdr avahi"
 RDEPENDS:${PN} = "soapysdr libavahi-client avahi-daemon"
 

--- a/recipes-ham/soapysdr/soapyrtlsdr_0.3.1.bb
+++ b/recipes-ham/soapysdr/soapyrtlsdr_0.3.1.bb
@@ -12,10 +12,8 @@ SRCREV = "bec4f0504b29369fd8ff651e6954b960991bc1b1"
 SRC_URI = "git://github.com/pothosware/SoapyRTLSDR.git;protocol=https;branch=master \
           "
 
-S = "${WORKDIR}/git"
-
 inherit cmake
-
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 DEPENDS = "rtlsdr soapysdr"
 RDEPENDS:${PN} = "rtlsdr soapysdr"
 FILES:${PN} += "${libdir}/*"

--- a/recipes-ham/soapysdr/soapysdr_0.8.1.bb
+++ b/recipes-ham/soapysdr/soapysdr_0.8.1.bb
@@ -12,6 +12,8 @@ SRCREV = "1cf5a539a21414ff509ff7d0eedfc5fa8edb90c6"
 SRC_URI = "git://github.com/pothosware/SoapySDR.git;protocol=https;branch=master \
           "
 
-S = "${WORKDIR}/git"
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+                 -DCMAKE_BUILD_TYPE=Release \
+                "
 
 inherit cmake


### PR DESCRIPTION
Yocto whinlatter release 5.3:  https://docs.yoctoproject.org/dev/migration-guides/migration-5.3.html
 - Add required Upstream-Status to all patches.
 - Remove S variable setting in all recipes as it is not longer permitted
 - Skip QA buildpaths check in some recipes
 - Move qsstv to use git
 - Add needed patch to goocanvas
 - Remove TMPDIR reference in output artifacts in goocanvas and fldigi
 - Add gpredict v2.5.1 recipe and use best practice .inc file